### PR TITLE
Decouple API logic from networking

### DIFF
--- a/WordPressComKit/SiteService.swift
+++ b/WordPressComKit/SiteService.swift
@@ -1,43 +1,81 @@
 import Foundation
 import Alamofire
 
-public class SiteService {
-    public init() {}
-    
-    public func fetchSite(siteID: Int, completion: (Site?, NSError?) -> Void) {
-        Alamofire
-            .request(RequestRouter.Site(siteID: siteID))
-            .validate()
-            .responseJSON { response in
-                guard response.result.isSuccess else {
-                    completion(nil, response.result.error)
-                    return
-                }
-                
-                let json = response.result.value as? [String: AnyObject]
-                let site = self.mapJSONToSite(json!)
-                
-                completion(site, nil)
+extension Result {
+    func map<T>(transform: Value -> T) -> Result<T, Error> {
+        return flatMap({ .Success(transform($0)) })
+    }
+
+    func flatMap<T>(transform: Value -> Result<T, Error>) -> Result<T, Error> {
+        switch self {
+        case .Success(let value):
+            return transform(value)
+        case .Failure(let error):
+            return .Failure(error)
         }
     }
-    
-    public func fetchSites(showActiveOnly: Bool = true, completion:([Site]?, NSError?) -> Void) {
+}
+
+// TODO: use a decent error
+let jsonDecodeError = NSError(domain: "WordPressComKit", code: -1, userInfo: nil)
+
+public typealias JSON = [String: AnyObject]
+
+public protocol Requester {
+    func requestJSON(request: NSURLRequest, completion: Result<JSON, NSError> -> Void)
+}
+
+struct AlamofireRequester: Requester {
+    func requestJSON(request: NSURLRequest, completion: Result<JSON, NSError> -> Void) {
         Alamofire
-            .request(RequestRouter.Sites(showActiveOnly: showActiveOnly))
+            .request(request)
             .validate()
             .responseJSON { response in
-                guard response.result.isSuccess else {
-                    completion(nil, response.result.error)
-                    return
-                }
-                
-                let json = response.result.value as? [String: AnyObject]
-                let sitesDictionary = json!["sites"] as! [[String: AnyObject]]
-                
-                let sites = sitesDictionary.map(self.mapJSONToSite)
-                
-                completion(sites, nil)
+                let result = response.result.flatMap({ result -> Result<JSON, NSError> in
+                    guard let json = result as? JSON else {
+                        return .Failure(jsonDecodeError)
+                    }
+                    return .Success(json)
+                })
+                completion(result)
         }
+    }
+}
+
+public struct SiteService {
+    let requester: Requester
+
+    public init(requester: Requester = AlamofireRequester()) {
+        self.requester = requester
+    }
+
+    public func fetchSite(siteID: Int) -> NSURLRequest {
+        return RequestRouter.Site(siteID: siteID).URLRequest
+    }
+
+    public func fetchSite(siteID: Int, completion: Result<Site, NSError> -> Void) {
+        let request = fetchSite(siteID)
+        requester.requestJSON(request) { result in
+            let site = result.map(self.mapJSONToSite)
+            completion(site)
+        }
+    }
+
+    public func fetchSites(showActiveOnly: Bool = true) -> NSURLRequest {
+        return RequestRouter.Sites(showActiveOnly: showActiveOnly).URLRequest
+    }
+
+    public func fetchSites(showActiveOnly: Bool = true, completion: Result<[Site], NSError> -> Void) {
+        let request = fetchSites(showActiveOnly)
+        requester.requestJSON(request) { result in
+            let sites = result.map(self.mapJSONToSites)
+            completion(sites)
+        }
+    }
+
+    func mapJSONToSites(json: [String: AnyObject]) -> [Site] {
+        let sitesDictionary = json["sites"] as! [[String: AnyObject]]
+        return sitesDictionary.map(mapJSONToSite)
     }
     
     func mapJSONToSite(json: [String: AnyObject]) -> Site {

--- a/WordPressComKitTests/SiteServiceTests.swift
+++ b/WordPressComKitTests/SiteServiceTests.swift
@@ -1,110 +1,55 @@
 import XCTest
-import OHHTTPStubs
-import WordPressComKit
+@testable import WordPressComKit
 
 class SiteServiceTests: XCTestCase {
-    var subject: SiteService!
+    let subject = SiteService()
     
     override func setUp() {
         super.setUp()
-        
-        subject = SiteService()
     }
     
     override func tearDown() {
         super.tearDown()
-        
-        subject = nil
-        OHHTTPStubs.removeAllStubs()
     }
     
     func testFetchSite() {
-        stub(isMethodGET() && isHost("public-api.wordpress.com") && isPath("/rest/v1.1/sites/1234")) { _ in
-            let stubPath = OHPathForFile("site.json", self.dynamicType)
-            return fixture(stubPath!, headers: ["Content-Type": "application/json"])
-        }
-        
-        let expectation = self.expectationWithDescription("FetchMe")
-        
-        subject.fetchSite(1234) { site, error -> Void in
-            expectation.fulfill()
-            
-            XCTAssertNotNil(site)
-            XCTAssertNil(error)
-            
-            XCTAssertEqual(66592863, site!.ID)
-            XCTAssertEqual("The Dangling Pointer", site!.name)
-            XCTAssertEqual("Sh*t my brain says and forgets about", site!.description)
-            XCTAssertEqual("http://astralbodi.es", site!.URL.absoluteString)
-            XCTAssertEqual("https://secure.gravatar.com/blavatar/6f0ad402b5cbfe40cef23c63488742a7", site!.icon)
-            XCTAssertEqual(false, site!.jetpack)
-            XCTAssertEqual(179, site!.postCount)
-            XCTAssertEqual(233, site!.subscribersCount)
-            XCTAssertEqual("en", site!.language)
-            XCTAssertEqual(true, site!.visible)
-            XCTAssertEqual(false, site!.isPrivate)
-            XCTAssertEqual(NSTimeZone(name: "America/Chicago"), site!.timeZone)
-        }
-        
-        self.waitForExpectationsWithTimeout(2.0, handler: nil)
-    }
-    
-    func testFetchSiteHTTP500Error() {
-        stub(isMethodGET() && isHost("public-api.wordpress.com") && isPath("/rest/v1.1/sites/1234")) { _ in
-            let stubPath = OHPathForFile("site.json", self.dynamicType)
-            return fixture(stubPath!, status: 500, headers: ["Content-Type": "application/json"])
-        }
-        
-        let expectation = self.expectationWithDescription("FetchMe")
-        
-        subject.fetchSite(1234) { site, error -> Void in
-            expectation.fulfill()
-            
-            XCTAssertNil(site)
-            XCTAssertNotNil(error)
-        }
-        
-        self.waitForExpectationsWithTimeout(2.0, handler: nil)
+        let request = subject.fetchSite(1234)
+        XCTAssertEqual("public-api.wordpress.com", request.URL?.host)
+        XCTAssertEqual("/rest/v1.1/sites/1234", request.URL?.path)
+
+        let json = loadJSONFile("site")
+        let site = subject.mapJSONToSite(json)
+
+        XCTAssertEqual(66592863, site.ID)
+        XCTAssertEqual("The Dangling Pointer", site.name)
+        XCTAssertEqual("Sh*t my brain says and forgets about", site.description)
+        XCTAssertEqual("http://astralbodi.es", site.URL.absoluteString)
+        XCTAssertEqual("https://secure.gravatar.com/blavatar/6f0ad402b5cbfe40cef23c63488742a7", site.icon)
+        XCTAssertEqual(false, site.jetpack)
+        XCTAssertEqual(179, site.postCount)
+        XCTAssertEqual(233, site.subscribersCount)
+        XCTAssertEqual("en", site.language)
+        XCTAssertEqual(true, site.visible)
+        XCTAssertEqual(false, site.isPrivate)
+        XCTAssertEqual(NSTimeZone(name: "America/Chicago"), site.timeZone)
     }
     
     func testFetchSites() {
-        stub(isMethodGET() && isHost("public-api.wordpress.com") && isPath("/rest/v1.1/me/sites")) { _ in
-            let stubPath = OHPathForFile("sites.json", self.dynamicType)
-            return fixture(stubPath!, headers: ["Content-Type": "application/json"])
-        }
-        
-        let expectation = self.expectationWithDescription("FetchMe")
-        
-        subject.fetchSites { sites, error -> Void in
-            expectation.fulfill()
-            
-            XCTAssertNotNil(sites)
-            XCTAssertNil(error)
-            
-            XCTAssertEqual(13, sites!.count)
-        }
-        
-        self.waitForExpectationsWithTimeout(2.0, handler: nil)
-    }
-    
-    func testFetchSitesHTTP500Error() {
-        stub(isMethodGET() && isHost("public-api.wordpress.com") && isPath("/rest/v1.1/me/sites")) { _ in
-            let stubPath = OHPathForFile("sites.json", self.dynamicType)
-            return fixture(stubPath!, status: 500, headers: ["Content-Type": "application/json"])
-        }
-        
-        let expectation = self.expectationWithDescription("FetchMe")
-        
-        subject.fetchSites { sites, error -> Void in
-            expectation.fulfill()
-            
-            XCTAssertNil(sites)
-            XCTAssertNotNil(error)
-        }
-        
-        self.waitForExpectationsWithTimeout(2.0, handler: nil)
-    }
-    
+        let request = subject.fetchSites()
+        XCTAssertEqual("public-api.wordpress.com", request.URL?.host)
+        XCTAssertEqual("/rest/v1.1/me/sites", request.URL?.path)
 
+        let json = loadJSONFile("sites")
+        let sites = subject.mapJSONToSites(json)
+        XCTAssertEqual(13, sites.count)
+    }
+    
+    private func loadJSONFile(name: String) -> JSON {
+        let bundle = NSBundle(forClass: self.dynamicType)
+        let path = bundle.pathForResource(name, ofType: "json")!
+        let data = NSData(contentsOfFile: path)!
+        let json = try! NSJSONSerialization.JSONObjectWithData(data, options: []) as! JSON
+        return json
+    }
     
 }


### PR DESCRIPTION
**DO NOT MERGE** This is just me continuing the conversation from [here](https://github.com/koke/WordPressComKit/pull/1/files#r55528633) with a practical example of how I'd make this more testable.

Extracts the actual network implementation and makes the service focus on
request serialization and response parsing.

Tests don't require HTTP stubbing anymore, and are synchronous.

It provides a default Alamofire network implementation, but it could easily be
integrated with any other network layer.

As this is just a proof of concept, it doesn't do error handling very well, and
I put all the extension code inside SiteService.

Since "Services" only serialize requests and parse responses in this design, I'd probably rename them to "Endpoint" or something else.

cc @astralbodies @jleandroperez 
