### PR TITLE
Use xcodebuild to run tests instead of xctool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-osx_image: xcode7.3
+osx_image: xcode8
 language: objective-c
 install:
 - gem install cocoapods -v 1.0.1 && pod repo update && pod install
-xcode_workspace: WordPressComKit.xcworkspace
-xcode_scheme: WordPressComKit
-xcode_sdk: iphonesimulator
+script:
+- ./test.sh

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+export LC_CTYPE="en_US.UTF-8"
+
+echo "- Building WordPressComKit"
+
+set -o pipefail &&
+    xcodebuild -workspace 'WordPressComKit.xcworkspace' \
+    -scheme 'WordPressComKit' \
+    clean build test \
+    -sdk iphonesimulator \
+    -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGN_IDENTITY= \
+    PROVISIONING_PROFILE= | \
+    tee ./xcode_raw_build.log | \
+    xcpretty --color --report junit --output ./xcode/results_unit.xml


### PR DESCRIPTION
- Also uses Xcode 8 for Swift 2.3 support

Fix https://github.com/Automattic/WordPressComKit/issues/17